### PR TITLE
Add unit tests for URL validation methods

### DIFF
--- a/src/utils_test.py
+++ b/src/utils_test.py
@@ -11,5 +11,15 @@ class TestValidationMethods(unittest.TestCase):
         self.assertTrue(utils.is_phone_valid('4255552368'))
         self.assertFalse(utils.is_phone_valid('invalid_string'))
 
+    def test_is_secure_url_valid(self):
+        self.assertTrue(utils.is_secure_url_valid('https://example.com'))
+        self.assertFalse(utils.is_secure_url_valid('http://example.com'))
+        self.assertFalse(utils.is_secure_url_valid('invalid_string'))
+
+    def test_is_github_url_valid(self):
+        self.assertTrue(utils.is_github_url_valid('https://github.com/octocademy/utils-library'))
+        self.assertFalse(utils.is_github_url_valid('https://example.com'))
+        self.assertFalse(utils.is_github_url_valid('invalid_string'))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request adds unit tests for the `is_secure_url_valid` and `is_github_url_valid` methods in the `src/utils.py` file, ensuring both positive and negative cases are covered.

- **Adds unit tests for `is_secure_url_valid`**: Tests that URLs starting with `https://` are correctly identified as valid, while those starting with `http://` or invalid strings are identified as invalid.
- **Adds unit tests for `is_github_url_valid`**: Tests that URLs pointing to GitHub repositories are correctly identified as valid, while non-GitHub URLs or invalid strings are identified as invalid.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/octocademy/utils-library/pull/7?shareId=88eea642-c27d-414e-a745-dba22f80ef7c).